### PR TITLE
requested changes to https://github.com/kiali/kiali/pull/3405

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SHELL=/bin/bash
 ROOTDIR=$(CURDIR)
 OUTDIR=${ROOTDIR}/_output
 
+# list for multi-arch image publishing
+TARGET_ARCHS ?= amd64 arm64 s390x ppc64le
+
 # Identifies the current build.
 # These will be embedded in the app and displayed when it starts.
 VERSION ?= v1.27.0-SNAPSHOT
@@ -40,7 +43,7 @@ CONTAINER_VERSION ?= dev
 
 # These two vars allow Jenkins to override values.
 QUAY_NAME ?= quay.io/${CONTAINER_NAME}
-QUAY_TAG = ${QUAY_NAME}:${CONTAINER_VERSION}
+QUAY_TAG ?= ${QUAY_NAME}:${CONTAINER_VERSION}
 
 # Identifies the Kiali operator container images that will be built
 OPERATOR_CONTAINER_NAME ?= ${IMAGE_ORG}/kiali-operator

--- a/deploy/docker/Dockerfile-multi-arch
+++ b/deploy/docker/Dockerfile-multi-arch
@@ -1,0 +1,30 @@
+FROM registry.access.redhat.com/ubi7-minimal AS base-amd64
+FROM registry.access.redhat.com/ubi8-minimal AS base-arm64
+FROM registry.access.redhat.com/ubi8-minimal AS base-s390x
+FROM registry.access.redhat.com/ubi8-minimal AS base-ppc64le
+
+FROM base-${TARGETARCH:-amd64}
+
+LABEL maintainer="kiali-dev@googlegroups.com"
+
+ENV KIALI_HOME=/opt/kiali \
+    PATH=$KIALI_HOME:$PATH
+
+WORKDIR $KIALI_HOME
+
+RUN microdnf install -y shadow-utils && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum && \
+    adduser --uid 1000 kiali
+
+ARG TARGETARCH
+COPY kiali-${TARGETARCH} $KIALI_HOME/kiali
+
+ADD console $KIALI_HOME/console/
+
+RUN chown -R kiali:kiali $KIALI_HOME/console && \
+    chmod -R g=u $KIALI_HOME/console
+
+USER 1000
+
+ENTRYPOINT ["/opt/kiali/kiali"]

--- a/make/Makefile.build.mk
+++ b/make/Makefile.build.mk
@@ -25,6 +25,14 @@ build: go-check
 	${GO_BUILD_ENVVARS} ${GO} build \
 		-o ${GOPATH}/bin/kiali -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"
 
+## build-linux-multi-arch: Build Kiali binary with arch suffix for multi-arch
+build-linux-multi-arch:
+	@for arch in ${TARGET_ARCHS}; do \
+		echo "Building for architecture [$${arch}]"; \
+		${GO_BUILD_ENVVARS} GOOS=linux GOARCH=$${arch} ${GO} build \
+			-o ${GOPATH}/bin/kiali-$${arch} -ldflags "-X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH}"; \
+	done
+
 ## install: Install missing dependencies. Runs `go install` internally
 install:
 	@echo Installing...

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -8,7 +8,7 @@
 	@echo Preparing container image files
 	@mkdir -p ${OUTDIR}/docker
 	@cp -r deploy/docker/* ${OUTDIR}/docker
-	@cp ${GOPATH}/bin/kiali ${OUTDIR}/docker
+	@cp ${GOPATH}/bin/kiali* ${OUTDIR}/docker
 
 .download-operator-sdk-if-needed:
 	@if [ "$(shell which operator-sdk 2>/dev/null || echo -n "")" == "" ]; then \
@@ -62,3 +62,34 @@ endif
 
 ## container-push: Pushes all container images to quay
 container-push: container-push-kiali-quay
+
+# Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md
+.ensure-docker-buildx:
+	@if docker buildx version > /dev/null 2>&1 || DOCKER_CLI_EXPERIMENTAL="${DOCKER_CLI_EXPERIMENTAL}" docker buildx version > /dev/null 2>&1 ; then \
+	  echo "'docker buildx' is available and enabled."; \
+	else \
+	  echo "installing docker buildx"; \
+	  mkdir -p ~/.docker/cli-plugins; \
+	  curl -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.$$(go env GOOS)-$$(go env GOARCH); \
+	  chmod a+x ~/.docker/cli-plugins/docker-buildx; \
+	  docker buildx version; \
+	  echo "'docker buildx' is available and enabled. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
+	fi
+
+# Ensure a local builder for multi-arch build. For more details, see: https://github.com/docker/buildx/blob/master/README.md#building-multi-platform-images
+.ensure-buildx-builder:
+	@if [[  ! -f ~/.docker/buildx/instances/kiali-builder ]]; then \
+  		echo "builder 'kiali-builder' not exists. creating 'kiali-builder'"; \
+  		DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx create --name=kiali-builder; \
+  	fi; \
+	if [[ $$(uname -s) == "Linux" ]]; then \
+	  	echo "setup qemu for Linux"; \
+		docker run --privileged --rm tonistiigi/binfmt --install all; \
+	fi; \
+	echo "buildx use 'kiali-builder'"; \
+	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx use kiali-builder
+
+## container-multi-arch-push-kiali-quay: Pushes the Kiali multi-arch image to quay.
+container-multi-arch-push-kiali-quay: .ensure-docker-buildx .ensure-buildx-builder .prepare-kiali-image-files
+	@echo Pushing Kiali multi-arch image to ${QUAY_TAG} using docker buildx
+	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx build --push $(foreach arch,${TARGET_ARCHS},--platform=linux/${arch}) $(foreach tag,${QUAY_TAG},--tag=${tag}) -f ${OUTDIR}/docker/Dockerfile-multi-arch ${OUTDIR}/docker

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -68,28 +68,41 @@ container-push: container-push-kiali-quay
 	@if docker buildx version > /dev/null 2>&1 || DOCKER_CLI_EXPERIMENTAL="${DOCKER_CLI_EXPERIMENTAL}" docker buildx version > /dev/null 2>&1 ; then \
 	  echo "'docker buildx' is available and enabled."; \
 	else \
-	  echo "installing docker buildx"; \
-	  mkdir -p ~/.docker/cli-plugins; \
-	  curl -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.$$(go env GOOS)-$$(go env GOARCH); \
-	  chmod a+x ~/.docker/cli-plugins/docker-buildx; \
-	  docker buildx version; \
-	  echo "'docker buildx' is available and enabled. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
+	  if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version > /dev/null 2>&1 ; then \
+	    echo "You do not have 'docker buildx' installed. Will now download and install it to [${HOME}/.docker/cli-plugins]."; \
+	    mkdir -p ${HOME}/.docker/cli-plugins; \
+	    curl -L --output ${HOME}/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.${GOOS}-${GOARCH}; \
+	    chmod a+x ${HOME}/.docker/cli-plugins/docker-buildx; \
+	    DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version; \
+	    if docker buildx version > /dev/null 2>&1 || DOCKER_CLI_EXPERIMENTAL="${DOCKER_CLI_EXPERIMENTAL}" docker buildx version > /dev/null 2>&1 ; then \
+	      echo "'docker buildx' has been installed and is enabled."; \
+	    else \
+	      echo "'docker buildx' has been installed but is not enabled by default. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
+	      exit 1; \
+	    fi \
+	  else \
+	    echo "'docker buildx' is available but not enabled. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
+	    exit 1; \
+	  fi \
 	fi
 
 # Ensure a local builder for multi-arch build. For more details, see: https://github.com/docker/buildx/blob/master/README.md#building-multi-platform-images
-.ensure-buildx-builder:
-	@if [[  ! -f ~/.docker/buildx/instances/kiali-builder ]]; then \
-  		echo "builder 'kiali-builder' not exists. creating 'kiali-builder'"; \
-  		DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx create --name=kiali-builder; \
-  	fi; \
-	if [[ $$(uname -s) == "Linux" ]]; then \
-	  	echo "setup qemu for Linux"; \
-		docker run --privileged --rm tonistiigi/binfmt --install all; \
+.ensure-buildx-builder: .ensure-docker-buildx
+	@if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx inspect kiali-builder > /dev/null 2>&1; then \
+	  echo "The buildx builder instance named 'kiali-builder' does not exist. Creating one now."; \
+	  if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx create --name=kiali-builder; then \
+	    echo "Failed to create the buildx builder 'kiali-builder'"; \
+	    exit 1; \
+	  fi \
 	fi; \
-	echo "buildx use 'kiali-builder'"; \
-	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx use kiali-builder
+	if [[ $$(uname -s) == "Linux" ]]; then \
+	  echo "Ensuring QEMU is set up for this Linux host"; \
+	  if ! docker run --privileged --rm tonistiigi/binfmt --install all; then \
+	    echo "Failed to ensure QEMU is set up. This build will be allowed to continue, but it may fail at a later step."; \
+	  fi \
+	fi; \
 
 ## container-multi-arch-push-kiali-quay: Pushes the Kiali multi-arch image to quay.
-container-multi-arch-push-kiali-quay: .ensure-docker-buildx .ensure-buildx-builder .prepare-kiali-image-files
+container-multi-arch-push-kiali-quay: .ensure-buildx-builder .prepare-kiali-image-files
 	@echo Pushing Kiali multi-arch image to ${QUAY_TAG} using docker buildx
-	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx build --push $(foreach arch,${TARGET_ARCHS},--platform=linux/${arch}) $(foreach tag,${QUAY_TAG},--tag=${tag}) -f ${OUTDIR}/docker/Dockerfile-multi-arch ${OUTDIR}/docker
+	DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx build --push --builder kiali-builder $(foreach arch,${TARGET_ARCHS},--platform=linux/${arch}) $(foreach tag,${QUAY_TAG},--tag=${tag}) -f ${OUTDIR}/docker/Dockerfile-multi-arch ${OUTDIR}/docker


### PR DESCRIPTION
This PR to the [kiali PR 3405](https://github.com/kiali/kiali/pull/3405) changes a few things:
 
1) The make target `.ensure-buildx-builder` should have `.ensure-docker-buildx` as a dependent target.
2) Do not download and install buildx if the user already has it but just didn't enable it via DOCKER_CLI_EXPERIMENTAL. Just spit out an error message telling the user to enable their already existing buildx.
3) After downloading and installing, it still may fail if not enabled. Make sure buildx is enabled and can run after downloading/installing - if not, spit out an error message and fail the build.
4) Don't change the user's default builder instance via `buildx use` - instead, use the `--builder` option to the `buildx build` command.
5) Don't rely on where buildx stores and names instance files (that can be considered a hidden implementation detail) - use `buildx inspect` to see if the kiali-builder instance exists.
6) Abort the build if the creation of kiali-builder instance fails.
7) Spit out a warning message if setting up QEMU fails, but allow the build to continue just in case the user already set it up successfully.
8) Add more verbose messages throughout to let the user know more clearly what is happening.